### PR TITLE
[11.0] expand pain support #517 - Travis Error Correction

### DIFF
--- a/account_banking_pain_base/models/account_payment_order.py
+++ b/account_banking_pain_base/models/account_payment_order.py
@@ -409,16 +409,19 @@ class AccountPaymentOrder(models.Model):
         partner = partner_bank.partner_id
         if partner.country_id:
             postal_address = etree.SubElement(party, 'PstlAdr')
-            if partner.zip:
-                pstcd = etree.SubElement(postal_address, 'PstCd')
-                pstcd.text = self._prepare_field(
-                    'Postal Code', 'partner.zip',
-                    {'partner': partner}, 16, gen_args=gen_args)
-            if partner.city:
-                twnnm = etree.SubElement(postal_address, 'TwnNm')
-                twnnm.text = self._prepare_field(
-                    'Town Name', 'partner.city',
-                    {'partner': partner}, 35, gen_args=gen_args)
+            if gen_args.get('pain_flavor').startswith(
+                    'pain.001.001.') or gen_args.get('pain_flavor').startswith(
+                    'pain.008.001.'):
+                if partner.zip:
+                    pstcd = etree.SubElement(postal_address, 'PstCd')
+                    pstcd.text = self._prepare_field(
+                        'Postal Code', 'partner.zip',
+                        {'partner': partner}, 16, gen_args=gen_args)
+                if partner.city:
+                    twnnm = etree.SubElement(postal_address, 'TwnNm')
+                    twnnm.text = self._prepare_field(
+                        'Town Name', 'partner.city',
+                        {'partner': partner}, 35, gen_args=gen_args)
             country = etree.SubElement(postal_address, 'Ctry')
             country.text = self._prepare_field(
                 'Country', 'partner.country_id.code',


### PR DESCRIPTION
Correcting following errors:
ERROR openerp_test odoo.addons.account_banking_sepa_credit_transfer.tests.test_sct: ` lxml.etree.DocumentInvalid: Element '{urn:iso:std:iso:20022:tech:xsd:pain.001.003.03}PstCd': This element is not expected. Expected is one of ( {urn:iso:std:iso:20022:tech:xsd:pain.001.003.03}Ctry, {urn:iso:std:iso:20022:tech:xsd:pain.001.003.03}AdrLine )., line 56

ERROR openerp_test odoo.addons.account_banking_sepa_direct_debit.tests.test_sdd: ` lxml.etree.DocumentInvalid: Element '{urn:iso:std:iso:20022:tech:xsd:pain.008.003.02}PstCd': This element is not expected. Expected is one of ( {urn:iso:std:iso:20022:tech:xsd:pain.008.003.02}Ctry, {urn:iso:std:iso:20022:tech:xsd:pain.008.003.02}AdrLine )., line 75

PstlAdr Tag contains only Ctry and AdrLine in pain.001.003.xx and pain.008.003.xx specifications used in Germany. PstCd and TwnNm are not allowed there.
So I added check of pain_flavor.